### PR TITLE
resolved inconsistency with debug window

### DIFF
--- a/ovpn_client.py
+++ b/ovpn_client.py
@@ -3554,7 +3554,11 @@ class Systray:
 		self.VAR['MAIN']['HIDE'] = False
 
 	def cb_destroy_debugwindow(self,event):
+		self.debug(1,"def cb_destroy_debugwindow")
 		self.DEBUGWINDOW_OPEN = False
+		# Switch debug modus off when debug window was closed with mouse click or ESC
+		self.switch_debugmode.set_active(False)  # while settings window is present
+		self.DEBUG = False                       # when settings window is destroyed already
 		GLib.idle_add(self.debug_window.destroy)
 
 	def cb_destroy_hidecellswindow(self,event):


### PR DESCRIPTION
Switch for 'Debug Modus' becomes inconsistent when closing debug window with mouse click or ESC.
There is no way to launch debug window again without changing the 'Debug Modus' switch.

Possible Solutions:
- Bind 'Debug Modus' to debug window and switch it off when the debug window was closed.
- Separate button or keyboard combination to open debug window when 'Debug Modus' is switched on (keep logfile)